### PR TITLE
Bugfix for L2 norm for AbstractLongDoubleVector

### DIFF
--- a/src/main/java/edu/jhu/prim/Primitives.java
+++ b/src/main/java/edu/jhu/prim/Primitives.java
@@ -2,6 +2,8 @@ package edu.jhu.prim;
 
 import java.io.Serializable;
 
+import edu.jhu.prim.util.SafeCast;
+
 
 /**
  * Methods and constants for primitive collections.
@@ -250,6 +252,9 @@ public class Primitives {
         public long v;
         public MutableLong() { }
         public MutableLong(long v) { this.v = v; }
+        public long sqrt() {
+            return SafeCast.safeDoubleToLong(Math.sqrt(v));
+        }
     }
 
     public static class MutableInt implements Serializable {
@@ -257,6 +262,9 @@ public class Primitives {
         public int v;
         public MutableInt() { }
         public MutableInt(int v) { this.v = v; }
+        public int sqrt() {
+            return SafeCast.safeDoubleToInt(Math.sqrt(v));
+        }
     }
     
     public static class MutableShort implements Serializable {
@@ -264,6 +272,9 @@ public class Primitives {
         public short v;
         public MutableShort() { }
         public MutableShort(short v) { this.v = v; }
+        public short sqrt() {
+            return SafeCast.safeIntToShort(SafeCast.safeDoubleToInt(Math.sqrt(v)));
+        }
     }
     
     public static class MutableDouble implements Serializable {
@@ -271,6 +282,9 @@ public class Primitives {
         public double v;
         public MutableDouble() { }
         public MutableDouble(double v) { this.v = v; }
+        public double sqrt() {
+            return Math.sqrt(v);
+        }
     }
 
     public static class MutableFloat implements Serializable {
@@ -278,6 +292,9 @@ public class Primitives {
         public float v;
         public MutableFloat() { }
         public MutableFloat(float v) { this.v = v; }
+        public float sqrt() {
+            return SafeCast.safeDoubleToFloat(Math.sqrt(v));
+        }
     }
     
  }

--- a/src/main/java/edu/jhu/prim/util/SafeCast.java
+++ b/src/main/java/edu/jhu/prim/util/SafeCast.java
@@ -33,6 +33,13 @@ public class SafeCast {
         return (int)l;
     }
     
+    public static long safeDoubleToLong(double d) {
+        if (d > (double)Long.MAX_VALUE || d < (double) Long.MIN_VALUE) {
+            throw new IllegalStateException("Cannot convert double to long: " + d);
+        }
+        return (long)d;
+    }
+    
     public static int safeDoubleToInt(double d) {
         if (d > (double)Integer.MAX_VALUE || d < (double) Integer.MIN_VALUE) {
             throw new IllegalStateException("Cannot convert double to int: " + d);

--- a/src/main/java/edu/jhu/prim/vector/AbstractLongDoubleVector.java
+++ b/src/main/java/edu/jhu/prim/vector/AbstractLongDoubleVector.java
@@ -77,7 +77,7 @@ public abstract class AbstractLongDoubleVector {
                 sum.v += val*val;
             }
         });
-        return sum.v;
+        return Math.sqrt(sum.v);
     }
     
     public double getInfNorm() {

--- a/src/main/java/edu/jhu/prim/vector/AbstractLongDoubleVector.java
+++ b/src/main/java/edu/jhu/prim/vector/AbstractLongDoubleVector.java
@@ -77,7 +77,7 @@ public abstract class AbstractLongDoubleVector {
                 sum.v += val*val;
             }
         });
-        return Math.sqrt(sum.v);
+        return sum.sqrt();
     }
     
     public double getInfNorm() {

--- a/src/main/java_generated/edu/jhu/prim/vector/AbstractIntDoubleVector.java
+++ b/src/main/java_generated/edu/jhu/prim/vector/AbstractIntDoubleVector.java
@@ -3,7 +3,6 @@ package edu.jhu.prim.vector;
 import edu.jhu.prim.Primitives.MutableDouble;
 import edu.jhu.prim.Primitives.MutableInt;
 import edu.jhu.prim.util.Lambda.FnIntDoubleToVoid;
-import edu.jhu.prim.util.math.FastMath;
 
 public abstract class AbstractIntDoubleVector {
 
@@ -78,7 +77,7 @@ public abstract class AbstractIntDoubleVector {
                 sum.v += val*val;
             }
         });
-        return Math.sqrt(sum.v);
+        return sum.sqrt();
     }
     
     public double getInfNorm() {

--- a/src/main/java_generated/edu/jhu/prim/vector/AbstractIntDoubleVector.java
+++ b/src/main/java_generated/edu/jhu/prim/vector/AbstractIntDoubleVector.java
@@ -3,6 +3,7 @@ package edu.jhu.prim.vector;
 import edu.jhu.prim.Primitives.MutableDouble;
 import edu.jhu.prim.Primitives.MutableInt;
 import edu.jhu.prim.util.Lambda.FnIntDoubleToVoid;
+import edu.jhu.prim.util.math.FastMath;
 
 public abstract class AbstractIntDoubleVector {
 
@@ -77,7 +78,7 @@ public abstract class AbstractIntDoubleVector {
                 sum.v += val*val;
             }
         });
-        return sum.v;
+        return Math.sqrt(sum.v);
     }
     
     public double getInfNorm() {

--- a/src/main/java_generated/edu/jhu/prim/vector/AbstractIntFloatVector.java
+++ b/src/main/java_generated/edu/jhu/prim/vector/AbstractIntFloatVector.java
@@ -3,7 +3,6 @@ package edu.jhu.prim.vector;
 import edu.jhu.prim.Primitives.MutableFloat;
 import edu.jhu.prim.Primitives.MutableInt;
 import edu.jhu.prim.util.Lambda.FnIntFloatToVoid;
-import edu.jhu.prim.util.math.FastMath;
 
 public abstract class AbstractIntFloatVector {
 
@@ -78,7 +77,7 @@ public abstract class AbstractIntFloatVector {
                 sum.v += val*val;
             }
         });
-        return Math.sqrt(sum.v);
+        return sum.sqrt();
     }
     
     public float getInfNorm() {

--- a/src/main/java_generated/edu/jhu/prim/vector/AbstractIntFloatVector.java
+++ b/src/main/java_generated/edu/jhu/prim/vector/AbstractIntFloatVector.java
@@ -3,6 +3,7 @@ package edu.jhu.prim.vector;
 import edu.jhu.prim.Primitives.MutableFloat;
 import edu.jhu.prim.Primitives.MutableInt;
 import edu.jhu.prim.util.Lambda.FnIntFloatToVoid;
+import edu.jhu.prim.util.math.FastMath;
 
 public abstract class AbstractIntFloatVector {
 
@@ -77,7 +78,7 @@ public abstract class AbstractIntFloatVector {
                 sum.v += val*val;
             }
         });
-        return sum.v;
+        return Math.sqrt(sum.v);
     }
     
     public float getInfNorm() {

--- a/src/main/java_generated/edu/jhu/prim/vector/AbstractIntIntVector.java
+++ b/src/main/java_generated/edu/jhu/prim/vector/AbstractIntIntVector.java
@@ -3,7 +3,6 @@ package edu.jhu.prim.vector;
 import edu.jhu.prim.Primitives.MutableInt;
 import edu.jhu.prim.Primitives.MutableInt;
 import edu.jhu.prim.util.Lambda.FnIntIntToVoid;
-import edu.jhu.prim.util.math.FastMath;
 
 public abstract class AbstractIntIntVector {
 
@@ -78,7 +77,7 @@ public abstract class AbstractIntIntVector {
                 sum.v += val*val;
             }
         });
-        return Math.sqrt(sum.v);
+        return sum.sqrt();
     }
     
     public int getInfNorm() {

--- a/src/main/java_generated/edu/jhu/prim/vector/AbstractIntIntVector.java
+++ b/src/main/java_generated/edu/jhu/prim/vector/AbstractIntIntVector.java
@@ -3,6 +3,7 @@ package edu.jhu.prim.vector;
 import edu.jhu.prim.Primitives.MutableInt;
 import edu.jhu.prim.Primitives.MutableInt;
 import edu.jhu.prim.util.Lambda.FnIntIntToVoid;
+import edu.jhu.prim.util.math.FastMath;
 
 public abstract class AbstractIntIntVector {
 
@@ -77,7 +78,7 @@ public abstract class AbstractIntIntVector {
                 sum.v += val*val;
             }
         });
-        return sum.v;
+        return Math.sqrt(sum.v);
     }
     
     public int getInfNorm() {

--- a/src/main/java_generated/edu/jhu/prim/vector/AbstractIntLongVector.java
+++ b/src/main/java_generated/edu/jhu/prim/vector/AbstractIntLongVector.java
@@ -3,7 +3,6 @@ package edu.jhu.prim.vector;
 import edu.jhu.prim.Primitives.MutableLong;
 import edu.jhu.prim.Primitives.MutableInt;
 import edu.jhu.prim.util.Lambda.FnIntLongToVoid;
-import edu.jhu.prim.util.math.FastMath;
 
 public abstract class AbstractIntLongVector {
 
@@ -78,7 +77,7 @@ public abstract class AbstractIntLongVector {
                 sum.v += val*val;
             }
         });
-        return Math.sqrt(sum.v);
+        return sum.sqrt();
     }
     
     public long getInfNorm() {

--- a/src/main/java_generated/edu/jhu/prim/vector/AbstractIntLongVector.java
+++ b/src/main/java_generated/edu/jhu/prim/vector/AbstractIntLongVector.java
@@ -3,6 +3,7 @@ package edu.jhu.prim.vector;
 import edu.jhu.prim.Primitives.MutableLong;
 import edu.jhu.prim.Primitives.MutableInt;
 import edu.jhu.prim.util.Lambda.FnIntLongToVoid;
+import edu.jhu.prim.util.math.FastMath;
 
 public abstract class AbstractIntLongVector {
 
@@ -77,7 +78,7 @@ public abstract class AbstractIntLongVector {
                 sum.v += val*val;
             }
         });
-        return sum.v;
+        return Math.sqrt(sum.v);
     }
     
     public long getInfNorm() {

--- a/src/main/java_generated/edu/jhu/prim/vector/AbstractLongIntVector.java
+++ b/src/main/java_generated/edu/jhu/prim/vector/AbstractLongIntVector.java
@@ -3,7 +3,6 @@ package edu.jhu.prim.vector;
 import edu.jhu.prim.Primitives.MutableInt;
 import edu.jhu.prim.Primitives.MutableLong;
 import edu.jhu.prim.util.Lambda.FnLongIntToVoid;
-import edu.jhu.prim.util.math.FastMath;
 
 public abstract class AbstractLongIntVector {
 
@@ -78,7 +77,7 @@ public abstract class AbstractLongIntVector {
                 sum.v += val*val;
             }
         });
-        return Math.sqrt(sum.v);
+        return sum.sqrt();
     }
     
     public int getInfNorm() {

--- a/src/main/java_generated/edu/jhu/prim/vector/AbstractLongIntVector.java
+++ b/src/main/java_generated/edu/jhu/prim/vector/AbstractLongIntVector.java
@@ -3,6 +3,7 @@ package edu.jhu.prim.vector;
 import edu.jhu.prim.Primitives.MutableInt;
 import edu.jhu.prim.Primitives.MutableLong;
 import edu.jhu.prim.util.Lambda.FnLongIntToVoid;
+import edu.jhu.prim.util.math.FastMath;
 
 public abstract class AbstractLongIntVector {
 
@@ -77,7 +78,7 @@ public abstract class AbstractLongIntVector {
                 sum.v += val*val;
             }
         });
-        return sum.v;
+        return Math.sqrt(sum.v);
     }
     
     public int getInfNorm() {

--- a/src/test/java/edu/jhu/prim/vector/AbstractLongDoubleVectorTest.java
+++ b/src/test/java/edu/jhu/prim/vector/AbstractLongDoubleVectorTest.java
@@ -217,13 +217,14 @@ public abstract class AbstractLongDoubleVectorTest {
     
     @Test
     public void testGetL2Norm() {
+        // TODO write some code to search for perfect squares which are the sum
+        // of other perfect squares (so this test has more cases and still works
+        // for the integer-valued vector variants).
         LongDoubleVector v1 = getLongDoubleVector();
-        v1.set(1, toDouble(11));
-        v1.set(3, toDouble(33));
-        v1.set(2, toDouble(-22));
-        v1.set(5, toDouble(-55));
+        v1.set(3, toDouble(-4));
+        v1.set(1, toDouble(3));
         
-        assertEquals(11*11 + 33*33 + 22*22 + 55*55, v1.getL2Norm(), 1e-13);
+        assertEquals(5, (double) v1.getL2Norm(), 1e-13);
     }
     
     @Test

--- a/src/test/java_generated/edu/jhu/prim/vector/AbstractIntDoubleVectorTest.java
+++ b/src/test/java_generated/edu/jhu/prim/vector/AbstractIntDoubleVectorTest.java
@@ -217,13 +217,14 @@ public abstract class AbstractIntDoubleVectorTest {
     
     @Test
     public void testGetL2Norm() {
+        // TODO write some code to search for perfect squares which are the sum
+        // of other perfect squares (so this test has more cases and still works
+        // for the integer-valued vector variants).
         IntDoubleVector v1 = getIntDoubleVector();
-        v1.set(1, toDouble(11));
-        v1.set(3, toDouble(33));
-        v1.set(2, toDouble(-22));
-        v1.set(5, toDouble(-55));
+        v1.set(3, toDouble(-4));
+        v1.set(1, toDouble(3));
         
-        assertEquals(11*11 + 33*33 + 22*22 + 55*55, v1.getL2Norm(), 1e-13);
+        assertEquals(5, (double) v1.getL2Norm(), 1e-13);
     }
     
     @Test

--- a/src/test/java_generated/edu/jhu/prim/vector/AbstractIntFloatVectorTest.java
+++ b/src/test/java_generated/edu/jhu/prim/vector/AbstractIntFloatVectorTest.java
@@ -217,13 +217,14 @@ public abstract class AbstractIntFloatVectorTest {
     
     @Test
     public void testGetL2Norm() {
+        // TODO write some code to search for perfect squares which are the sum
+        // of other perfect squares (so this test has more cases and still works
+        // for the integer-valued vector variants).
         IntFloatVector v1 = getIntFloatVector();
-        v1.set(1, toFloat(11));
-        v1.set(3, toFloat(33));
-        v1.set(2, toFloat(-22));
-        v1.set(5, toFloat(-55));
+        v1.set(3, toFloat(-4));
+        v1.set(1, toFloat(3));
         
-        assertEquals(11*11 + 33*33 + 22*22 + 55*55, v1.getL2Norm(), 1e-13);
+        assertEquals(5, (float) v1.getL2Norm(), 1e-13);
     }
     
     @Test

--- a/src/test/java_generated/edu/jhu/prim/vector/AbstractIntIntVectorTest.java
+++ b/src/test/java_generated/edu/jhu/prim/vector/AbstractIntIntVectorTest.java
@@ -217,13 +217,14 @@ public abstract class AbstractIntIntVectorTest {
     
     @Test
     public void testGetL2Norm() {
+        // TODO write some code to search for perfect squares which are the sum
+        // of other perfect squares (so this test has more cases and still works
+        // for the integer-valued vector variants).
         IntIntVector v1 = getIntIntVector();
-        v1.set(1, toInt(11));
-        v1.set(3, toInt(33));
-        v1.set(2, toInt(-22));
-        v1.set(5, toInt(-55));
+        v1.set(3, toInt(-4));
+        v1.set(1, toInt(3));
         
-        assertEquals(11*11 + 33*33 + 22*22 + 55*55, v1.getL2Norm());
+        assertEquals(5, (int) v1.getL2Norm());
     }
     
     @Test

--- a/src/test/java_generated/edu/jhu/prim/vector/AbstractIntLongVectorTest.java
+++ b/src/test/java_generated/edu/jhu/prim/vector/AbstractIntLongVectorTest.java
@@ -217,13 +217,14 @@ public abstract class AbstractIntLongVectorTest {
     
     @Test
     public void testGetL2Norm() {
+        // TODO write some code to search for perfect squares which are the sum
+        // of other perfect squares (so this test has more cases and still works
+        // for the integer-valued vector variants).
         IntLongVector v1 = getIntLongVector();
-        v1.set(1, toLong(11));
-        v1.set(3, toLong(33));
-        v1.set(2, toLong(-22));
-        v1.set(5, toLong(-55));
+        v1.set(3, toLong(-4));
+        v1.set(1, toLong(3));
         
-        assertEquals(11*11 + 33*33 + 22*22 + 55*55, v1.getL2Norm());
+        assertEquals(5, (long) v1.getL2Norm());
     }
     
     @Test

--- a/src/test/java_generated/edu/jhu/prim/vector/AbstractLongIntVectorTest.java
+++ b/src/test/java_generated/edu/jhu/prim/vector/AbstractLongIntVectorTest.java
@@ -217,13 +217,14 @@ public abstract class AbstractLongIntVectorTest {
     
     @Test
     public void testGetL2Norm() {
+        // TODO write some code to search for perfect squares which are the sum
+        // of other perfect squares (so this test has more cases and still works
+        // for the integer-valued vector variants).
         LongIntVector v1 = getLongIntVector();
-        v1.set(1, toInt(11));
-        v1.set(3, toInt(33));
-        v1.set(2, toInt(-22));
-        v1.set(5, toInt(-55));
+        v1.set(3, toInt(-4));
+        v1.set(1, toInt(3));
         
-        assertEquals(11*11 + 33*33 + 22*22 + 55*55, v1.getL2Norm());
+        assertEquals(5, (int) v1.getL2Norm());
     }
     
     @Test


### PR DESCRIPTION
- used to return the squared L2 norm, now return the actual L2 norm

NOTE: I used Math.sqrt instead of another variant like FastMath because the cost of the sqrt should be small compared to iterating over the entire vector, and Java's Math.sqrt is "standard".
